### PR TITLE
Remove chmod +x from Dockerfile

### DIFF
--- a/beacon-chain/Dockerfile
+++ b/beacon-chain/Dockerfile
@@ -4,8 +4,6 @@ FROM chainsafe/lodestar:${UPSTREAM_VERSION}
 COPY jwtsecret.hex /jwtsecret
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-RUN chmod +x /usr/local/bin/entrypoint.sh
-
 EXPOSE $BEACON_API_PORT
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -4,6 +4,4 @@ FROM chainsafe/lodestar:${UPSTREAM_VERSION}
 COPY api-token.txt /var/lib/data/validator-db/api-token.txt
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-RUN chmod +x /usr/local/bin/entrypoint.sh
-
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]


### PR DESCRIPTION
**Motivation**

- Better align with other CL packages
- Reduce package size by removing build layer

**Description**

- scripts are already executable (100755)
- remove chmod +x from Dockerfile
